### PR TITLE
Add VCR to ensure no HTTP request is made

### DIFF
--- a/lita-gitlab-ci-hipchat.gemspec
+++ b/lita-gitlab-ci-hipchat.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "fabrication"

--- a/spec/fixtures/cassettes/hipchat.yml
+++ b/spec/fixtures/cassettes/hipchat.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hipchat.com/v2/room/Test/notification?auth_token=6ed672d3a40eecadaf6cf4f83fc36a88
+    body:
+      encoding: UTF-8
+      string: '{"room_id":"Test","from":"lita","message":"<p>Build for <a href=\"\"></a>
+        (): <strong>success</strong>!</p>","message_format":"html","color":"green","notify":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 06 Nov 2014 23:33:44 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1415316840.0'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 06 Nov 2014 23:33:44 GMT
+recorded_with: VCR 2.9.3

--- a/spec/lita/handlers/gitlab_ci_hipchat_spec.rb
+++ b/spec/lita/handlers/gitlab_ci_hipchat_spec.rb
@@ -7,16 +7,24 @@ describe Lita::Handlers::GitlabCiHipchat, lita_handler: true do
     let(:request)           { double(Rack::Request) }
     let(:response)          { double(Rack::Response) }
     let(:body)              { StringIO.new(json) }
-    let(:hipchat)           { double(HipChat).as_null_object }
-    let(:json)              { "{ \"build_status\": \"success\", \"push_data\": { \"commits\": [] } }" }
+    let(:json)              { '{ "build_status": "success", "push_data": { "commits": [] } }' }
     let(:json_parsed)       { JSON.parse(json) }
     let(:message)           { double(Lita::GitlabCi::BuildMessage).as_null_object }
+    let(:api_token)         { '6ed672d3a40eecadaf6cf4f83fc36a88' }
+    let(:room)              { 'Test' }
+    let(:hipchat)           { subject.send(:hipchat) }
     let(:gitlab_ci_receive) { subject.receive(request, response) }
 
     before do
+      VCR.insert_cassette('hipchat')
       allow(request).to receive(:body).and_return(body)
-      allow(subject).to receive(:hipchat).and_return(hipchat)
       allow(Lita::GitlabCi::BuildMessage).to receive(:new).and_return(message)
+      registry.config.handlers.gitlab_ci_hipchat.api_token = api_token
+      registry.config.handlers.gitlab_ci_hipchat.room      = room
+    end
+
+    after do
+      VCR.eject_cassette
     end
 
     it 'parses body to JSON' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require "simplecov"
-require "coveralls"
+require 'simplecov'
+require 'coveralls'
+require 'vcr'
+
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
@@ -11,3 +13,7 @@ require "lita-gitlab-ci-hipchat"
 require "lita/rspec"
 Lita.version_3_compatibility_mode = false
 
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/cassettes'
+  config.hook_into :webmock
+end


### PR DESCRIPTION
Allow to test that the HipChat gem is correctly called without making a
real connection to its API.
